### PR TITLE
Add AI proxy and switch client to proxy/picsum

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -1,0 +1,54 @@
+// Vercel Serverless Function — /api/ai
+// Proxies requests to Perplexity AI server-side.
+// This keeps the API key secret (never sent to the browser) and solves CORS.
+
+export default async function handler(req, res) {
+    // Only allow POST requests
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+
+    const apiKey = process.env.PERPLEXITY_API_KEY;
+    const model = process.env.PERPLEXITY_MODEL || 'sonar-pro';
+
+    if (!apiKey) {
+        return res.status(500).json({ error: 'AI API key is not configured on the server.' });
+    }
+
+    try {
+        const { messages, max_tokens } = req.body;
+
+        if (!messages || !Array.isArray(messages)) {
+            return res.status(400).json({ error: 'Invalid request body: messages array is required.' });
+        }
+
+        const response = await fetch('https://api.perplexity.ai/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${apiKey}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                model,
+                messages,
+                max_tokens: max_tokens || 1000,
+            }),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            console.error('Perplexity API error:', response.status, errorText);
+            return res.status(response.status).json({
+                error: `Perplexity API returned ${response.status}`,
+                details: errorText,
+            });
+        }
+
+        const data = await response.json();
+        return res.status(200).json(data);
+
+    } catch (error) {
+        console.error('Server error in /api/ai:', error);
+        return res.status(500).json({ error: 'Internal server error', details: error.message });
+    }
+}

--- a/src/appwrite/config.js
+++ b/src/appwrite/config.js
@@ -209,111 +209,85 @@ async getPublicPosts() {
 
     async generateAIContent(topic, tone = 'informative', length = 'medium') {
         try {
-            const aiEndpoint = conf.aiApiEndpoint; 
-            
-            // Construct dynamic prompt
             const prompt = `Write a ${length} blog post about "${topic}" in a ${tone} tone.`;
 
-            if (!aiEndpoint || aiEndpoint === 'YOUR_AI_API_ENDPOINT') {
-                console.warn("AI API Endpoint not configured. Returning mock content for demonstration.");
-                // Simulate network delay
-                await new Promise(resolve => setTimeout(resolve, 2000));
-                
-                return `<h1>${topic.charAt(0).toUpperCase() + topic.slice(1)}: A Comprehensive Guide</h1>
-<p>This is a simulated AI response tailored to your request about <strong>${topic}</strong>. In a real scenario, this content would be dynamic.</p>
-<h2>Why ${topic} Matters</h2>
-<p>Understanding the nuances of ${topic} is crucial in today's landscape. A ${tone} approach reveals key insights.</p>
-<ul>
-    <li>Key Insight 1: Innovation drives progress.</li>
-    <li>Key Insight 2: Adaptability is essential.</li>
-    <li>Key Insight 3: Community engagement fosters growth.</li>
-</ul>
-<p><em>(This is a mock generated response. To use real AI, please configure your AI API endpoint in the app settings.)</em></p>`;
-            }
-
-            const response = await axios.post(aiEndpoint, {
-                model: conf.aiModel || 'sonar-pro',
-                messages: [
-                    {
-                        role: "system",
-                        content: `You are a professional blog writer. Generate a structured blog post in HTML format. 
-                        Use <h1> for the main title, <h2> for subheadings, <p> for paragraphs, and <ul>/<li> for lists.
-                        Do not wrap the output in markdown code blocks or \`\`\`html. Return only the raw HTML content.
-                        Make sure the generated content matches the requested tone: ${tone}.`
-                    },
-                    {
-                        role: "user",
-                        content: prompt
-                    }
-                ],
-                max_tokens: length === 'short' ? 500 : (length === 'long' ? 2000 : 1000), 
-            }, {
-                headers: {
-                    'Authorization': `Bearer ${conf.aiApiKey}`, 
-                    'Content-Type': 'application/json',
-                }
+            // Call our Vercel serverless proxy — no API key exposed to browser, no CORS issues
+            const response = await fetch(conf.aiProxyEndpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    messages: [
+                        {
+                            role: 'system',
+                            content: `You are a professional blog writer. Generate a structured blog post in HTML format.
+                            Use <h1> for the main title, <h2> for subheadings, <p> for paragraphs, and <ul>/<li> for lists.
+                            Do not wrap the output in markdown code blocks or \`\`\`html. Return only the raw HTML content.
+                            Make sure the generated content matches the requested tone: ${tone}.`
+                        },
+                        { role: 'user', content: prompt }
+                    ],
+                    max_tokens: length === 'short' ? 500 : (length === 'long' ? 2000 : 1000),
+                }),
             });
 
-            // Perplexity/OpenAI chat completion response structure
-            return response.data.choices[0].message.content; 
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `AI proxy returned ${response.status}`);
+            }
+
+            const data = await response.json();
+            return data.choices[0].message.content;
 
         } catch (error) {
-            console.error("Error generating AI content:", error);
-            // Fallback for demo purposes even on error
-            return "<p>Failed to generate content from AI service. Please check your API configuration.</p>";
+            console.error('Error generating AI content:', error);
+            return '<p>Failed to generate content from AI service. Please try again later.</p>';
         }
     }
 
-    async generateAITopics(baseTopic = "latest technology trends") {
+    async generateAITopics(baseTopic = 'latest technology trends') {
         try {
-            const aiEndpoint = conf.aiApiEndpoint;
-            
-            if (!aiEndpoint || aiEndpoint === 'YOUR_AI_API_ENDPOINT') {
-                 // Simulate network delay
-                 await new Promise(resolve => setTimeout(resolve, 1500));
-                 return [
-                    "The Future of Artificial Intelligence in Healthcare",
-                    "Sustainable Tech: Innovations for a Greener Planet",
-                    "Web Development Trends to Watch in 2024",
-                    "Cybersecurity: Protecting Your Digital Footprint",
-                    "The Rise of Quantum Computing"
-                 ];
-            }
-
-            const response = await axios.post(aiEndpoint, {
-                model: conf.aiModel || 'sonar-pro',
-                messages: [
-                    {
-                        role: "system",
-                        content: "You are a creative blog topic generator. Return a JSON array of 5 catchy blog post titles based on the user's input. Return ONLY the JSON array strings, no extra text."
-                    },
-                    {
-                        role: "user",
-                        content: `Suggest 5 catchy blog post titles related to: ${baseTopic}`
-                    }
-                ],
-                max_tokens: 300, 
-            }, {
-                headers: {
-                    'Authorization': `Bearer ${conf.aiApiKey}`, 
-                    'Content-Type': 'application/json',
-                }
+            // Call our Vercel serverless proxy — no API key exposed to browser, no CORS issues
+            const response = await fetch(conf.aiProxyEndpoint, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    messages: [
+                        {
+                            role: 'system',
+                            content: "You are a creative blog topic generator. Return a JSON array of 5 catchy blog post titles based on the user's input. Return ONLY the JSON array, no extra text or markdown."
+                        },
+                        {
+                            role: 'user',
+                            content: `Suggest 5 catchy blog post titles related to: ${baseTopic}`
+                        }
+                    ],
+                    max_tokens: 300,
+                }),
             });
 
-             // Attempt to parse JSON response. Perplexity/LLMs might wrap in markdown sometimes so we clean it.
-            let content = response.data.choices[0].message.content;
-            // Clean markdown code blocks if present
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.error || `AI proxy returned ${response.status}`);
+            }
+
+            const data = await response.json();
+            let content = data.choices[0].message.content;
+
+            // Clean markdown code blocks if the model wraps in them
             content = content.replace(/```json/g, '').replace(/```/g, '').trim();
-            
+
             try {
                 return JSON.parse(content);
             } catch (e) {
-                // If parsing fails, try to split by newlines as a fallback
-                return content.split('\n').filter(line => line.trim().length > 0).map(line => line.replace(/^\d+\.\s*/, '').replace(/"/g, ''));
+                // Fallback: split by newlines
+                return content
+                    .split('\n')
+                    .filter(line => line.trim().length > 0)
+                    .map(line => line.replace(/^\d+\.\s*/, '').replace(/"/g, ''));
             }
 
         } catch (error) {
-            console.error("Error generating AI topics:", error);
+            console.error('Error generating AI topics:', error);
             return [];
         }
     }

--- a/src/conf/conf.js
+++ b/src/conf/conf.js
@@ -1,18 +1,15 @@
 const conf = {
     appwriteUrl : String(import.meta.env.VITE_APPWRITE_URL),
     appwriteProjectId : String(import.meta.env.VITE_APPWRITE_PROJECT_ID),
-
     appwriteDatabaseId : String(import.meta.env.VITE_APPWRITE_DATABASE_ID),
-
     appwriteCollectionId : String(import.meta.env.VITE_APPWRITE_COLLECTION_ID),
-
     appwriteBucketId : String(import.meta.env.VITE_APPWRITE_BUCKET_ID),
-
     editorApi : String(import.meta.env.VITE_TINY_EDITOR_API),
-    aiApiEndpoint: String(import.meta.env.VITE_PERPLEXITY_API_URL || 'https://api.perplexity.ai/chat/completions'),
-    aiApiKey: String(import.meta.env.VITE_PERPLEXITY_API_KEY || ''),
-    aiModel: String(import.meta.env.VITE_PERPLEXITY_MODEL || 'sonar-pro'),
-}
 
+    // AI calls are proxied through /api/ai (Vercel serverless function).
+    // The actual Perplexity API key lives ONLY in Vercel environment variables (server-side).
+    // We do NOT expose VITE_PERPLEXITY_API_KEY here anymore.
+    aiProxyEndpoint: '/api/ai',
+}
 
 export default conf;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+    "rewrites": [
+        {
+            "source": "/api/(.*)",
+            "destination": "/api/$1"
+        },
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
Introduce a Vercel serverless AI proxy (api/ai.js) to forward chat completion requests to Perplexity server-side, keeping the API key out of the browser and avoiding CORS. Update client configuration (src/conf/conf.js) to use a local aiProxyEndpoint ('/api/ai') and remove exposure of the Perplexity API key. Replace direct axios calls in appwrite config with fetch calls to the proxy and improve error handling and response parsing for generateAIContent and generateAITopics. Simplify image generation in AIGenerator.jsx by removing Puter.js (which caused auth/401 issues) and using Picsum photos as a reliable fallback, plus minor logging/message tweaks. Add vercel.json rewrites for API and SPA routing.